### PR TITLE
Stake Plus - July 2024 - 160 Engineering Hours

### DIFF
--- a/payouts/202407_Stakeplus.md
+++ b/payouts/202407_Stakeplus.md
@@ -1,0 +1,7 @@
+# \<Stake Plus\>
+| Date | Hours | Hour type | Link | Description | 
+|---|---|---|---|---|
+| 07/2024 | 150 | Engineering | https://github.com/ibp-network/ibp-geodns | Spent 150 hours designing, building and implementing ibp-geodns module for powerdns to support new sub domains.
+
+## Total Hours:
+- Engineering: 150

--- a/payouts/202407_Stakeplus.md
+++ b/payouts/202407_Stakeplus.md
@@ -1,7 +1,7 @@
 # \<Stake Plus\>
 | Date | Hours | Hour type | Link | Description | 
 |---|---|---|---|---|
-| 07/2024 | 150 | Engineering | https://github.com/ibp-network/ibp-geodns | Spent 150 hours designing, building and implementing ibp-geodns module for powerdns to support new sub domains.
+| 07/2024 | 160 | Engineering | https://github.com/ibp-network/ibp-geodns | Spent 160 hours designing, building and implementing ibp-geodns module for powerdns to support new sub domains.
 
 ## Total Hours:
-- Engineering: 150
+- Engineering: 160


### PR DESCRIPTION
Stake plus spent 160 hours this month designing and implementing the ibp-geodns module for power dns. This module will eventually allow members to manage geodns resolution themselves further decentralizing the service. The module itself is a remote backend that provides dynamic resolution with a number of different features. 